### PR TITLE
Add integration tests to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,11 +21,13 @@ devToolsProject.run(
   },
 )
 
-devToolsProject.run(
-  deployWhen: { return devToolsProject.shouldDeploy() },
-  deploy: { data ->
-    String versionNumber = readFile('VERSION').trim()
-    version.tag(versionNumber)
-    version.forwardMinorBranch(versionNumber)
-  },
-)
+if (devToolsProject.shouldDeploy()) {
+  devToolsProject.run(
+    deployWhen: { return true },
+    deploy: { data ->
+      String versionNumber = readFile('VERSION').trim()
+      version.tag(versionNumber)
+      version.forwardMinorBranch(versionNumber)
+    },
+  )
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,7 @@
 library(identifier: 'ableton-utils@0.22', changelog: false)
 library(identifier: 'groovylint@0.13', changelog: false)
+// Get python-utils library from current commit so it can test itself in this Jenkinsfile
+library "python-utils@${params.JENKINS_COMMIT}"
 
 
 devToolsProject.run(
@@ -20,6 +22,34 @@ devToolsProject.run(
     jupiter.publishDocs("${data['docs']}/", 'Ableton/python-pipeline-utils')
   },
 )
+
+eventRecorder.timedStage('Integration Test') {
+  Map stages = [failFast: false]
+  Map preinstalledPythonVersions = [linux: '3.10', mac: '3.9', win: '3.7']
+
+  ['linux', 'mac', 'win'].each { osType ->
+    stages[osType.capitalize()] = {
+      eventRecorder.timedNode("generic-${osType}") {
+        echo 'Test VirtualEnv.create'
+        String preinstalledPythonVersion = preinstalledPythonVersions[osType]
+        Object venv = virtualenv.create("python${preinstalledPythonVersion}")
+        String venvVersion = venv.run(returnStdout: true, script: 'python --version')
+        assert venvVersion.startsWith("Python ${preinstalledPythonVersion}")
+
+        if (isUnix()) {
+          echo 'Test VirtualEnv.createWithPyenv'
+          Object pyvenv = virtualenv.createWithPyenv('3.8.0')
+          String pyvenvVersion =
+            pyvenv.run(returnStdout: true, script: 'python --version')
+          echo pyvenvVersion
+          assert pyvenvVersion.trim() == 'Python 3.8.0'
+        }
+      }
+    }
+  }
+
+  parallel(stages)
+}
 
 if (devToolsProject.shouldDeploy()) {
   devToolsProject.run(

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,12 +5,8 @@ library(identifier: 'groovylint@0.13', changelog: false)
 devToolsProject.run(
   test: { data ->
     parallel(failFast: false,
-      groovydoc: {
-        data['docs'] = groovydoc.generate()
-      },
-      groovylint: {
-        groovylint.check('./Jenkinsfile,./*.gradle,**/*.groovy')
-      },
+      groovydoc: { data['docs'] = groovydoc.generate() },
+      groovylint: { groovylint.check('./Jenkinsfile,./*.gradle,**/*.groovy') },
       junit: {
         try {
           sh './gradlew test'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,9 @@ devToolsProject.run(
   publish: { data ->
     jupiter.publishDocs("${data['docs']}/", 'Ableton/python-pipeline-utils')
   },
+)
+
+devToolsProject.run(
   deployWhen: { return devToolsProject.shouldDeploy() },
   deploy: { data ->
     String versionNumber = readFile('VERSION').trim()


### PR DESCRIPTION
We have lots of unit tests, but they mock the behavior of the underlying
Python interpreter. To ensure that things really work, we should add
some integration tests that actually run on real nodes of different OS
types.