### PR TITLE
Fix integration test on macOS Big Sur

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,11 +38,11 @@ eventRecorder.timedStage('Integration Test') {
 
         if (isUnix()) {
           echo 'Test VirtualEnv.createWithPyenv'
-          Object pyvenv = virtualenv.createWithPyenv('3.8.0')
+          Object pyvenv = virtualenv.createWithPyenv('3.10.3')
           String pyvenvVersion =
             pyvenv.run(returnStdout: true, script: 'python --version')
           echo pyvenvVersion
-          assert pyvenvVersion.trim() == 'Python 3.8.0'
+          assert pyvenvVersion.trim() == 'Python 3.10.3'
         }
       }
     }


### PR DESCRIPTION
Attempting to install Python 3.8.0 on generic-mac-xcode12.5 nodes fails
with:

    ./Modules/posixmodule.c:9084:15: error: implicit declaration of function
    'sendfile' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
            ret = sendfile(in, out, offset, &sbytes, &sf, flags);
                  ^
    1 error generated.

This was not caught in 2fc0361edfeea6b83c5f15b6b6ef853fb915d871 because
the various CI runs only used generic-mac-xcode12.2 nodes, which run
macOS Catalina.

We solve this by installing the Python version we install the most with
pyenv in Ableton repositories (based on
https://github.com/search?q=org%3AAbleton+createWithPyenv&type=code)