### PR TITLE
Define VIRTUAL_ENV environment variable

### DIFF
--- a/src/com/ableton/VirtualEnv.groovy
+++ b/src/com/ableton/VirtualEnv.groovy
@@ -86,7 +86,9 @@ class VirtualEnv implements Serializable {
    * @param body Closure body to execute.
    */
   void inside(Closure body) {
-    script.withEnv(["PATH+VENVBIN=${venvBinDir}"]) { body() }
+    script.withEnv(["PATH+VENVBIN=${venvBinDir}", "VIRTUAL_ENV=${venvRootDir}"]) {
+      body()
+    }
   }
 
   /**


### PR DESCRIPTION
When we implemented `VirtualEnv.inside` in 7cd11f9, we thought that the
`VIRTUAL_ENV` environment variable was only used by the `activate` and
`deactivate` scripts, and therefore it would be safe to only set the
`PATH` variable.

However, we have encountered at least one piece of software which relies
on this variable being set, and there may be others out there as well.
In order to keep compatibility with them, we should define this
variable.
