### PR TITLE
Force build on Xcode 12.2 Macs (for now)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,12 @@ eventRecorder.timedStage('Integration Test') {
 
   ['linux', 'mac', 'win'].each { osType ->
     stages[osType.capitalize()] = {
-      eventRecorder.timedNode("generic-${osType}") {
+      // TODO: Fix this once the 12.5 (and newer) Macs are working
+      String nodeLabel = "generic-${osType}"
+      if (osType == 'mac') {
+        nodeLabel = 'generic-mac-xcode12.2'
+      }
+      eventRecorder.timedNode(nodeLabel) {
         echo 'Test VirtualEnv.create'
         String preinstalledPythonVersion = preinstalledPythonVersions[osType]
         Object venv = virtualenv.create("python${preinstalledPythonVersion}")


### PR DESCRIPTION
There is a problem with our other Mac nodes (which run Big Sur and Xcode
12.5) where they can't use the `virtualenv` tool. Until this is sorted
out, we force the build to be done on Xcode 12.2 Mac nodes.
