### PR TITLE
Cleanup: remove obsolete TODO

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,11 +27,7 @@ eventRecorder.timedStage('Integration Test') {
 
   ['linux', 'mac', 'win'].each { osType ->
     stages[osType.capitalize()] = {
-      // TODO: Fix this once the 12.5 (and newer) Macs are working
       String nodeLabel = "generic-${osType}"
-      if (osType == 'mac') {
-        nodeLabel = 'generic-mac-xcode15.2'
-      }
       eventRecorder.timedNode(nodeLabel) {
         echo 'Test VirtualEnv.create'
         Object venv = virtualenv.create('python3')


### PR DESCRIPTION
We only have generic-mac-xcode15.2 nodes these days; we've eliminated
the Xcode 12.2 pool about 6 weeks ago.
